### PR TITLE
More efficient data transfer

### DIFF
--- a/emblaze/_version.py
+++ b/emblaze/_version.py
@@ -4,5 +4,5 @@
 # Copyright (c) venkatesh-sivaraman.
 # Distributed under the terms of the Modified BSD License.
 
-version_info = (0, 9, 0)
+version_info = (0, 9, 3)
 __version__ = ".".join(map(str, version_info))

--- a/emblaze/datasets.py
+++ b/emblaze/datasets.py
@@ -275,7 +275,7 @@ class Embedding(ColumnarData):
                 if (pos[0] >= bbox[0] and pos[0] <= bbox[1] and
                     pos[1] >= bbox[2] and pos[1] <= bbox[3])]
 
-    def to_json(self):
+    def to_json(self, compressed=True):
         """
         Converts this embedding into a JSON object. Requires that the embedding
         have an n x 2 array at the Field.POSITION key.
@@ -292,21 +292,43 @@ class Embedding(ColumnarData):
         if neighbors is None:
             print("Warning: The embedding has no computed nearest neighbors, so none will be displayed. You may want to call compute_neighbors() to generate them.")
         
-        for id_val, index in zip(self.ids, indexes):
-            obj = {
-                "x": positions[index, 0],
-                "y": positions[index, 1],
-                "color": colors[index]
-            }
+        if compressed:
+            result["_format"] = "compressed"
+            # Specify the type name that will be used to encode the point IDs.
+            # This is important because the highlight array takes up the bulk
+            # of the space when transferring to file/widget.
+            dtype, type_name = choose_integer_type(self.ids)
+            result["_idtype"] = type_name
+            result["_length"] = len(self)
+            result["ids"] = encode_numerical_array(self.ids, dtype)
+            
+            result["x"] = encode_numerical_array(positions[:,0])
+            result["y"] = encode_numerical_array(positions[:,1])
+            result["color"] = encode_object_array(colors)
             if alphas is not None:
-                obj["alpha"] = alphas[index]
+                result["alpha"] = encode_numerical_array(alphas)
             if sizes is not None:
-                obj["r"] = sizes[index]
+                result["r"] = encode_numerical_array(sizes)
             if neighbors is not None:
-                obj["highlight"] = neighbors[index].tolist()
-            else:
-                obj["highlight"] = []
-            result[id_val] = obj
+                result["highlight"] = encode_numerical_array(neighbors.flatten(),
+                                                             astype=dtype,
+                                                             interval=neighbors.shape[1])
+        else:
+            for id_val, index in zip(self.ids, indexes):
+                obj = {
+                    "x": positions[index, 0],
+                    "y": positions[index, 1],
+                    "color": colors[index]
+                }
+                if alphas is not None:
+                    obj["alpha"] = alphas[index]
+                if sizes is not None:
+                    obj["r"] = sizes[index]
+                if neighbors is not None:
+                    obj["highlight"] = neighbors[index].tolist()
+                else:
+                    obj["highlight"] = []
+                result[id_val] = obj
         
         return standardize_json(result)
     
@@ -315,45 +337,40 @@ class Embedding(ColumnarData):
         """
         Builds a 2-dimensional Embedding object from the given JSON object.
         """
-        try:
-            ids = [int(id_val) for id_val in list(data.keys())]
-            data = {int(k): v for k, v in data.items()}
-        except:
-            ids = list(data.keys())
-        ids = sorted(ids)
         mats = {}
-        mats[Field.POSITION] = np.array([[data[id_val]["x"], data[id_val]["y"]] for id_val in ids])
-        mats[Field.COLOR] = np.array([data[id_val]["color"] for id_val in ids])
-        if "alpha" in data[ids[0]]:
-            mats[Field.ALPHA] = np.array([data[id_val]["alpha"] for id_val in ids])
-        if "r" in data[ids[0]]:
-            mats[Field.RADIUS] = np.array([data[id_val]["r"] for id_val in ids])
-        if "highlight" in data[ids[0]]:
-            mats[Field.NEIGHBORS] = np.array([data[id_val]["highlight"] for id_val in ids])
+        if data.get("_format", "expanded") == "compressed":
+            dtype = np.dtype(data["_idtype"])
+            ids = decode_numerical_array(data["ids"], dtype)
+            mats[Field.POSITION] = np.hstack([
+                decode_numerical_array(data["x"]).reshape(-1, 1),
+                decode_numerical_array(data["y"]).reshape(-1, 1),
+            ])
+            mats[Field.COLOR] = np.array(decode_object_array(data["color"]))
+            if "alpha" in data:
+                mats[Field.ALPHA] = decode_numerical_array(data["alpha"])
+            if "r" in data:
+                mats[Field.RADIUS] = decode_numerical_array(data["r"])
+            if "highlight" in data:
+                mats[Field.NEIGHBORS] = decode_numerical_array(data["highlight"], dtype)
+        else:
+            try:
+                ids = [int(id_val) for id_val in list(data.keys())]
+                data = {int(k): v for k, v in data.items()}
+            except:
+                ids = list(data.keys())
+            ids = sorted(ids)
+            
+            mats[Field.POSITION] = np.array([[data[id_val]["x"], data[id_val]["y"]] for id_val in ids])
+            mats[Field.COLOR] = np.array([data[id_val]["color"] for id_val in ids])
+            if "alpha" in data[ids[0]]:
+                mats[Field.ALPHA] = np.array([data[id_val]["alpha"] for id_val in ids])
+            if "r" in data[ids[0]]:
+                mats[Field.RADIUS] = np.array([data[id_val]["r"] for id_val in ids])
+            if "highlight" in data[ids[0]]:
+                mats[Field.NEIGHBORS] = np.array([data[id_val]["highlight"] for id_val in ids])
+                
         return Embedding(mats, ids=ids, label=label, metric=metric, parent=parent)
     
-    @staticmethod
-    def from_json(data, label=None, metric='euclidean', parent=None):
-        """
-        Builds a 2-dimensional Embedding object from the given JSON object.
-        """
-        try:
-            ids = [int(id_val) for id_val in list(data.keys())]
-            data = {int(k): v for k, v in data.items()}
-        except:
-            ids = list(data.keys())
-        ids = sorted(ids)
-        mats = {}
-        mats[Field.POSITION] = np.array([[data[id_val]["x"], data[id_val]["y"]] for id_val in ids])
-        mats[Field.COLOR] = np.array([data[id_val]["color"] for id_val in ids])
-        if "alpha" in data[ids[0]]:
-            mats[Field.ALPHA] = np.array([data[id_val]["alpha"] for id_val in ids])
-        if "r" in data[ids[0]]:
-            mats[Field.RADIUS] = np.array([data[id_val]["r"] for id_val in ids])
-        if "highlight" in data[ids[0]]:
-            mats[Field.NEIGHBORS] = np.array([data[id_val]["highlight"] for id_val in ids])
-        return Embedding(mats, ids=ids, label=label, metric=metric, parent=parent)
-            
     def align_to(self, base_frame, ids=None, return_transform=False, base_transform=None, allow_flips=True):
         """
         Aligns this embedding to the base frame. The frames are aligned based
@@ -494,12 +511,12 @@ class EmbeddingSet:
         for emb in self.embeddings:
             emb.compute_neighbors(n_neighbors=n_neighbors, metric=metric)
 
-    def to_json(self):
+    def to_json(self, compressed=True):
         """
         Converts this set of embeddings into a JSON object.
         """
         return {
-            "data": [emb.to_json() for emb in self.embeddings],
+            "data": [emb.to_json(compressed=compressed) for emb in self.embeddings],
             "frameLabels": [emb.label or "Frame {}".format(i) for i, emb in enumerate(self.embeddings)]
         }
 

--- a/emblaze/utils.py
+++ b/emblaze/utils.py
@@ -177,7 +177,8 @@ def choose_integer_type(values):
 def encode_numerical_array(arr, astype=np.float32, positions=None, interval=None):
     """
     Encodes the given numpy array into a base64 representation for fast transfer
-    to the widget frontend. astype will likely be np.float32 or np.int32.
+    to the widget frontend. The array will be encoded as a sequence of numbers
+    with type 'astype'.
     
     If positions is not None, it should be a numpy array of positions at which the
     array for each ID *ends*. For example, if there are ten IDs and ten numbers
@@ -207,7 +208,8 @@ def decode_numerical_array(obj, astype=np.float32):
     Decodes the given compressed dict into an array of the given dtype. The 
     dict should contain a 'values' key (base64 string) and optionally a
     'positions' key (base64 string to be turned into an int32 array, defining
-    the shape of a 2d matrix).
+    the shape of a 2d matrix) or an 'interval' key (integer defining the number
+    of columns in the 2d matrix).
     """
     values = np.frombuffer(base64.decodebytes(obj["values"].encode('ascii')), dtype=astype)
     if "positions" in obj:

--- a/emblaze/utils.py
+++ b/emblaze/utils.py
@@ -6,6 +6,7 @@ import json
 import datetime
 import platform
 import os
+import base64
 
 class Field:
     """Standardized field names for embeddings and projections. These data can
@@ -85,7 +86,7 @@ def standardize_json(o, round_digits=4):
     and rounding floats to save space.
     """
     if isinstance(o, (float, np.float32, np.float64)): return round(float(o), round_digits)
-    if isinstance(o, (np.int64, np.int32)): return int(o)
+    if isinstance(o, (np.int64, np.int32, np.uint8)): return int(o)
     if isinstance(o, dict): return {standardize_json(k, round_digits): standardize_json(v, round_digits) for k, v in o.items()}
     if isinstance(o, (list, tuple)): return [standardize_json(x, round_digits) for x in o]
     return o
@@ -148,3 +149,80 @@ class LoggingHelper:
         
         with open(self.filepath, "w") as file:
             json.dump(current_data, file)
+            
+def choose_integer_type(values):
+    """
+    Chooses the best integer type (i.e. np.(u)int(8|16|32)) for the given set
+    of values. Returns the dtype and its name.
+    """
+    min_val = values.min()
+    max_val = values.max()
+    rng = max_val - min_val
+    if min_val < 0:
+        if rng > 2 ** 32 - 1:
+            return np.int64, "i8"
+        elif rng > 2 ** 16 - 1:
+            return np.int32, "i4"
+        elif rng > 2 ** 8 - 1:
+            return np.int16, "i2"
+        return np.int8, "i1"
+    elif rng > 2 ** 32 - 1:
+        return np.uint64, "u8"
+    elif rng > 2 ** 16 - 1:
+        return np.uint32, "u4"
+    elif rng > 2 ** 8 - 1:
+        return np.uint16, "u2"
+    return np.uint8, "u1"
+    
+def encode_numerical_array(arr, astype=np.float32, positions=None, interval=None):
+    """
+    Encodes the given numpy array into a base64 representation for fast transfer
+    to the widget frontend. astype will likely be np.float32 or np.int32.
+    
+    If positions is not None, it should be a numpy array of positions at which to
+    read the array for each ID. For example, if there are ten IDs and ten numbers
+    in the array for each ID, the positions array would be [0, 10, 20, ..., 90].
+    
+    If interval is not None, it is passed into the result object directly (and
+    signifies the same as positions, but with a regularly spaced interval).
+    """
+    result = { "values": base64.b64encode(arr.astype(astype)).decode('ascii') }
+    if positions is not None:
+        result["positions"] = base64.b64encode(positions.astype(np.int32)).decode('ascii')
+    if interval is not None:
+        result["interval"] = interval
+    return result
+
+def encode_object_array(arr):
+    """
+    Encodes the given array as a base64 string of a JSON string.
+    """
+    if isinstance(arr, np.ndarray):
+        arr = arr.tolist()
+        
+    return { "values": base64.b64encode(json.dumps(standardize_json(arr)).encode("utf-8")).decode('ascii') }
+
+def decode_numerical_array(obj, astype=np.float32):
+    """
+    Decodes the given compressed dict into an array of the given dtype. The 
+    dict should contain a 'values' key (base64 string) and optionally a
+    'positions' key (base64 string to be turned into an int32 array, defining
+    the shape of a 2d matrix).
+    """
+    values = np.frombuffer(base64.decodebytes(obj["values"].encode('ascii')), dtype=astype)
+    if "positions" in obj:
+        positions = np.frombuffer(base64.decodebytes(obj["positions"].encode('ascii')), dtype=np.int32)
+        deltas = positions[1:] - positions[:-1]
+        assert np.allclose(deltas, deltas[0]), "cannot currently decode numerical arrays with non-standard positions array"
+        values = values.reshape(-1, deltas[0])
+    elif "interval" in obj:
+        values = values.reshape(-1, obj["interval"])
+    return values
+
+def decode_object_array(obj):
+    """
+    Decodes the given object's 'values' key into a JSON object.
+    """
+    return json.loads(base64.b64decode(obj["values"].encode('ascii')))
+
+

--- a/emblaze/utils.py
+++ b/emblaze/utils.py
@@ -179,9 +179,9 @@ def encode_numerical_array(arr, astype=np.float32, positions=None, interval=None
     Encodes the given numpy array into a base64 representation for fast transfer
     to the widget frontend. astype will likely be np.float32 or np.int32.
     
-    If positions is not None, it should be a numpy array of positions at which to
-    read the array for each ID. For example, if there are ten IDs and ten numbers
-    in the array for each ID, the positions array would be [0, 10, 20, ..., 90].
+    If positions is not None, it should be a numpy array of positions at which the
+    array for each ID *ends*. For example, if there are ten IDs and ten numbers
+    in the array for each ID, the positions array would be [10, 20, ..., 90, 100].
     
     If interval is not None, it is passed into the result object directly (and
     signifies the same as positions, but with a regularly spaced interval).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emblaze",
-  "version": "0.9.0",
+  "version": "0.9.3",
   "description": "Interactive Jupyter notebook widget for visually comparing embeddings",
   "keywords": [
     "jupyter",

--- a/src/visualization/TemporalVisualization.svelte
+++ b/src/visualization/TemporalVisualization.svelte
@@ -15,8 +15,7 @@
 
   export let useHalos = false;
 
-  export let thumbnailsURL = null;
-  export let thumbnailData = null;
+  export let thumbnailProvider;
   let thumbnailViewer;
 
   export let data = null;
@@ -70,10 +69,6 @@
       thumbnailIDs = selectedIDs;
       thumbnailHover = false;
     }
-  }
-
-  export function updateThumbnails() {
-    if (!!thumbnailViewer) thumbnailViewer.updateImageThumbnails();
   }
 
   // Autocomplete
@@ -176,6 +171,7 @@
         <DefaultThumbnailViewer
           bind:this={thumbnailViewer}
           dataset={data}
+          {thumbnailProvider}
           primaryTitle={thumbnailHover ? 'Hovered Point' : 'Selection'}
           frame={currentFrame}
           {previewFrame}

--- a/src/visualization/components/Thumbnail.svelte
+++ b/src/visualization/components/Thumbnail.svelte
@@ -122,6 +122,10 @@
     border-radius: 4px;
   }
 
+  .thumbnail-row p {
+    margin-bottom: 0;
+  }
+
   .thumbnail-text-section {
     width: 100%;
   }

--- a/src/visualization/models/dataset.js
+++ b/src/visualization/models/dataset.js
@@ -55,24 +55,17 @@ export class Dataset {
     if (rawData.length == 0) return;
 
     this.frames = rawData.map((frame, f) => {
-      return new ColumnarFrame(frame, this.frameLabels[f], (el) => {
-        let point = [el.x, el.y];
-        if (
-          !!this.frameTransformations &&
-          this.frameTransformations.length > f
-        ) {
-          point = transformPoint(this.frameTransformations[f], point);
-        }
-        return {
-          x: point[0],
-          y: point[1],
-          color: this.colorKey == 'constant' ? 0.0 : el[this.colorKey] || 0.0,
-          alpha: el.alpha != undefined ? el.alpha : 1.0,
-          highlight: el.highlight.map((h) => parseInt(h)),
-          r: 1.0,
-          visible: true,
-        };
+      let ret = new ColumnarFrame(frame, this.frameLabels[f], {
+        color: (el) =>
+          this.colorKey == 'constant' ? 0.0 : el[this.colorKey] || 0.0,
+        alpha: (el) => (el.alpha != undefined ? el.alpha : 1.0),
+        r: (el) => (el.r != undefined ? el.r : 1.0),
+        visible: () => true,
       });
+      if (!!this.frameTransformations && this.frameTransformations.length > f) {
+        ret.transform(this.frameTransformations[f]);
+      }
+      return ret;
     });
 
     let allIDs = new Set();

--- a/src/visualization/models/frames.js
+++ b/src/visualization/models/frames.js
@@ -2,6 +2,86 @@ import { transformPoint, distance2, shuffle } from '../utils/helpers.js';
 import { kdTree } from '../utils/kdTree.js';
 
 /**
+ * Handles interpreting the standard input formats for the widget. If arrayType
+ * is:
+ *  - Array: compressed base-64 string should be a JSON string
+ *  - Float32Array/Int32Array: string should be a compressed string representing
+ *    an array of floats/ints
+ *
+ * Courtesy of https://gist.github.com/sketchpunk/f5fa58a56dcfe6168a9328e7c32a4fd4
+ */
+function decodeBase64String(base64String, arrayType) {
+  if (arrayType === Array) {
+    return JSON.parse(window.atob(base64String));
+  } else {
+    var blob = window.atob(base64String), // Base64 string converted to a char array
+      bytesPerElement = arrayType.BYTES_PER_ELEMENT,
+      fLen = blob.length / bytesPerElement, // How many floats can be made, but be even
+      dView = makeTypedReader(arrayType),
+      result = new arrayType(fLen), // Final Output at the correct size
+      p = 0; // Position
+
+    for (var j = 0; j < fLen; j++) {
+      p = j * bytesPerElement;
+      for (var k = 0; k < bytesPerElement; k++)
+        dView.set(k, blob.charCodeAt(p + k));
+      result[j] = dView.get();
+    }
+    return result;
+  }
+}
+
+function makeTypedReader(arrayType) {
+  let base = new DataView(new ArrayBuffer(arrayType.BYTES_PER_ELEMENT));
+  let result = {
+    set(offset, value) {
+      base.setUint8(offset, value);
+    },
+  };
+  if (arrayType === Float32Array) result.get = () => base.getFloat32(0, true);
+  else if (arrayType === Float64Array)
+    result.get = () => base.getFloat64(0, true);
+  else if (arrayType === Int32Array) result.get = () => base.getInt32(0, true);
+  else if (arrayType === Uint32Array)
+    result.get = () => base.getUint32(0, true);
+  else if (arrayType === Int16Array) result.get = () => base.getInt16(0, true);
+  else if (arrayType === Uint16Array)
+    result.get = () => base.getUint16(0, true);
+  else if (arrayType === Int8Array) result.get = () => base.getInt8(0, true);
+  else if (arrayType === Uint8Array) result.get = () => base.getUint8(0, true);
+  else
+    console.error(
+      "unsupported array type - note that int64 arrays aren't fully supported yet"
+    );
+  return result;
+}
+
+/**
+ * Converts the given format string (e.g. 'i8', 'u1') into a TypedArray type.
+ *
+ */
+function selectArrayType(format) {
+  switch (format) {
+    case 'i8':
+      return BigInt64Array;
+    case 'i4':
+      return Int32Array;
+    case 'i2':
+      return Int16Array;
+    case 'i1':
+      return Int8Array;
+    case 'u8':
+      return BigUint64Array;
+    case 'u4':
+      return Uint32Array;
+    case 'u2':
+      return Uint16Array;
+    case 'u1':
+      return Uint8Array;
+  }
+}
+
+/**
  * A class for representing a fixed number of objects using arrays. The
  * constructor accepts a schema, which is an object whose keys will be the
  * field names that the object stores, and whose values are objects containing
@@ -10,6 +90,11 @@ import { kdTree } from '../utils/kdTree.js';
  *     For arbitrary object types, Array may be used.
  * - field: The name of the field in the provided data from which to obtain the
  *     values to store. If this is not provided, the key name is used.
+ *
+ * If the input to ColumnarData is compressed, the data object must contain a
+ * length property indicating the number of objects in each field. The remaining
+ * keys of the object should be the fields defined in the schema, encoded as
+ * base 64 strings according to the correct types.
  */
 export class ColumnarData {
   columns = {};
@@ -19,45 +104,125 @@ export class ColumnarData {
   length = 0;
   computedData = {};
 
-  constructor(schema, data, objTransform = null) {
+  constructor(schema, data, additionalFields = null) {
     this.schema = schema;
-    this.length = Object.keys(data).length;
-    Object.keys(this.schema).forEach((col) => {
-      let len = this.length;
-      if (this.schema[col].nested) {
-        // This column will contain the flattened contents of arrays of
-        // integers. We need to compute the exact length of the column and store
-        // an additional column for "nest position", indicating where to jump to
-        // for each index.
-        this.nestPositionColumns[col] = new Int32Array(this.length);
-        len = Object.keys(data)
-          .map((id) => (!!objTransform ? objTransform(data[id], id) : data[id]))
-          .reduce(
-            (total, pt) => total + pt[this.schema[col].field || col].length,
-            0
-          );
+
+    if (data['_format'] == 'compressed') {
+      this.length = data['_length'];
+
+      // Get the ids list as an Int32Array
+      if (!data.ids) {
+        console.error('compressed data object has no ids field');
+        return;
       }
-      this.columns[col] = new this.schema[col].array(len);
-    });
-    Object.keys(data).forEach((id, i) => {
-      id = parseInt(id);
-      this.idMapping.set(id, i);
-      let pt = data[id];
-      if (!!objTransform) {
-        pt = objTransform(pt, id);
-      }
+      let idType = selectArrayType(data['_idtype']);
+      let ids = decodeBase64String(data.ids.values, idType);
+      ids.forEach((id, i) => this.idMapping.set(id, i));
+
+      // first read all compressed arrays from the input
       Object.keys(this.schema).forEach((col) => {
-        let fieldVal = pt[this.schema[col].field || col];
+        let fieldName = this.schema[col].field || col;
+
+        let val = data[fieldName]; // this is a JSON object
+        if (!val) return;
+
         if (this.schema[col].nested) {
-          // Set the flattened array and the current position
-          let currentPos = i == 0 ? 0 : this.nestPositionColumns[col][i - 1];
-          fieldVal.forEach(
-            (val, j) => (this.columns[col][currentPos + j] = val)
+          // The value should contain an additional 'positions' key or an 'interval' key
+          if (!!val.positions) {
+            this.nestPositionColumns[col] = decodeBase64String(
+              val.positions,
+              Int32Array
+            );
+          } else if (!!val.interval) {
+            this.nestPositionColumns[col] = new Int32Array(this.length);
+            for (let k = 0; k < this.length; k++) {
+              this.nestPositionColumns[col][k] = k * val.interval;
+            }
+          }
+        }
+        this.columns[col] = decodeBase64String(
+          val.values,
+          this.schema[col].array == 'id' ? idType : this.schema[col].array
+        );
+        if (!this.schema[col].nested && this.columns[col].length != this.length)
+          console.warn(
+            `field '${fieldName}' has incorrect length: expected ${this.length}, got ${this.columns[col].length}`
           );
-          this.nestPositionColumns[col][i] = currentPos + fieldVal.length;
-        } else this.columns[col][i] = fieldVal;
       });
-    });
+
+      // Now go back and add additional fields from the input argument
+      if (!!additionalFields) {
+        let newCols = {};
+        Object.keys(additionalFields).forEach((f) => {
+          let colSchema = this.schema[f];
+          if (!colSchema) {
+            console.warn("can't add additional fields without a schema column");
+            return;
+          }
+          if (colSchema.nested) {
+            console.warn(
+              "can't currently add nested columns using additional fields"
+            );
+            return;
+          }
+          let arrayType =
+            colSchema.array == 'id' ? Int32Array : colSchema.array;
+          let newCol = new arrayType(this.length);
+          newCols[f] = newCol;
+        });
+        ids.forEach((id, i) => {
+          let pt = this.byID(id);
+          Object.keys(additionalFields).forEach((f) => {
+            newCols[f][i] = additionalFields[f](pt);
+          });
+        });
+        Object.keys(newCols).forEach(
+          (col) => (this.columns[col] = newCols[col])
+        );
+      }
+    } else {
+      this.length = Object.keys(data).length;
+      Object.keys(this.schema).forEach((col) => {
+        let len = this.length;
+        if (this.schema[col].nested) {
+          // This column will contain the flattened contents of arrays of
+          // integers. We need to compute the exact length of the column and store
+          // an additional column for "nest position", indicating where to jump to
+          // for each index.
+          this.nestPositionColumns[col] = new Int32Array(this.length);
+          len = Object.keys(data)
+            .map((id) => data[id])
+            .reduce(
+              (total, pt) => total + pt[this.schema[col].field || col].length,
+              0
+            );
+        }
+        let arrayType =
+          this.schema[col].array == 'id' ? Int32Array : this.schema[col].array;
+        this.columns[col] = new arrayType(len);
+      });
+      Object.keys(data).forEach((id, i) => {
+        id = parseInt(id);
+        this.idMapping.set(id, i);
+        let pt = data[id];
+        if (!!additionalFields) {
+          Object.keys(additionalFields).forEach((f) => {
+            pt[f] = additionalFields[f](pt, id);
+          });
+        }
+        Object.keys(this.schema).forEach((col) => {
+          let fieldVal = pt[this.schema[col].field || col];
+          if (this.schema[col].nested) {
+            // Set the flattened array and the current position
+            let currentPos = i == 0 ? 0 : this.nestPositionColumns[col][i - 1];
+            fieldVal.forEach(
+              (val, j) => (this.columns[col][currentPos + j] = val)
+            );
+            this.nestPositionColumns[col][i] = currentPos + fieldVal.length;
+          } else this.columns[col][i] = fieldVal;
+        });
+      });
+    }
   }
 
   byID(id) {
@@ -145,7 +310,7 @@ const FRAME_SCHEMA = {
   alpha: { array: Float32Array },
   r: { array: Float32Array },
   color: { array: Array },
-  highlightIndexes: { array: Int32Array, field: 'highlight', nested: true },
+  highlightIndexes: { array: 'id', field: 'highlight', nested: true },
   visible: { array: Array },
 };
 
@@ -153,8 +318,8 @@ export class ColumnarFrame extends ColumnarData {
   _kdTree;
   title;
 
-  constructor(frame, title, objTransform = null) {
-    super(FRAME_SCHEMA, frame, objTransform);
+  constructor(frame, title, additionalFields = null) {
+    super(FRAME_SCHEMA, frame, additionalFields);
     this.title = title;
   }
 

--- a/src/visualization/models/frames.js
+++ b/src/visualization/models/frames.js
@@ -136,7 +136,8 @@ export class ColumnarData {
           } else if (!!val.interval) {
             this.nestPositionColumns[col] = new Int32Array(this.length);
             for (let k = 0; k < this.length; k++) {
-              this.nestPositionColumns[col][k] = k * val.interval;
+              // the nest positions list the position of the END of each row's values
+              this.nestPositionColumns[col][k] = (k + 1) * val.interval;
             }
           }
         }


### PR DESCRIPTION
Adds a new compression method to reduce the amount of data that needs to pass from the kernel backend to the client. Instead of sending the entire dataset as a blob of uncompressed JSON, we now store each field as a base64-compressed typed array. In particular, this allows us to save a lot of space on the neighbors matrix, which is the main space occupant in the data structure. If the number of IDs is less than 65535, we can store all neighbors as `Uint16` integers, which means each value only takes two bytes as opposed to four. This allows for ~60% reduction in data size when transferring to file or to the widget.

Also bumps version number to 0.9.3.