### PR TITLE
Multimodal thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ w = emblaze.Viewer(embeddings=embeddings, thumbnails=thumbnails)
 w
 ```
 
+You can also visualize embeddings with multimodal labels (i.e. where some points have text labels and others have image labels) by initializing an `emblaze.CombinedThumbnails` instance with a list of other `Thumbnails` objects to combine.
+
 ### Interactive Analysis
 
 Once you have loaded a `Viewer` instance in the notebook, you can read and write its properties to dynamically work with the visualization. The following properties are reactive:

--- a/emblaze/__init__.py
+++ b/emblaze/__init__.py
@@ -7,7 +7,7 @@
 from .viewer import Viewer
 from .datasets import Embedding, EmbeddingSet
 from .utils import ProjectionTechnique, Field, PreviewMode
-from .thumbnails import Thumbnails, TextThumbnails, ImageThumbnails
+from .thumbnails import Thumbnails, TextThumbnails, ImageThumbnails, CombinedThumbnails
 from ._version import __version__, version_info
 
 from .nbextension import _jupyter_nbextension_paths

--- a/src/visualization/components/Autocomplete.svelte
+++ b/src/visualization/components/Autocomplete.svelte
@@ -48,7 +48,7 @@
     data-toggle="dropdown"
     on:focus={() => (autocompleteDropdownVisible = true)}
     on:blur={() => {
-      setTimeout(() => (autocompleteDropdownVisible = false), 100);
+      setTimeout(() => (autocompleteDropdownVisible = false), 500);
     }}
     style={fillWidth ? 'width: 100%;' : ''}
   />


### PR DESCRIPTION
Adds support for creating `Thumbnails` objects with both images and text, where some thumbnails only have images and others only have text. This was already supported by the existing architecture of the frontend, so this PR simply adds support for defining such thumbnail sets in the backend. To use the feature, define some text and image thumbnails and specify what point IDs each thumbnail belongs to, then create a `CombinedThumbnails` object:

```python
text_thumbnails = emblaze.TextThumbnails(names, ids=text_ids)
image_thumbnails = emblaze.ImageThumbnails(images, ids=image_ids)
combined = emblaze.CombinedThumbnails([text_thumbnails, image_thumbnails])
```