### PR TITLE
Safari 15 fixes

### DIFF
--- a/emblaze/_version.py
+++ b/emblaze/_version.py
@@ -4,5 +4,5 @@
 # Copyright (c) venkatesh-sivaraman.
 # Distributed under the terms of the Modified BSD License.
 
-version_info = (0, 9, 3)
+version_info = (0, 9, 4)
 __version__ = ".".join(map(str, version_info))

--- a/emblaze/thumbnails.py
+++ b/emblaze/thumbnails.py
@@ -256,8 +256,8 @@ class ImageThumbnails(Thumbnails):
         descriptions = None
         if "items" in data:
             items = data["items"]
-            names = [items[id_val]["name"] for id_val in ids]
-            descriptions = [items[id_val].get("description", "") for id_val in ids]
+            names = [items[str(id_val)]["name"] for id_val in ids]
+            descriptions = [items[str(id_val)].get("description", "") for id_val in ids]
 
         return ImageThumbnails(None,
                                spritesheets=spritesheets,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "emblaze",
-  "version": "0.9.0",
+  "version": "0.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2649,368 +2649,187 @@
       }
     },
     "@pixi/accessibility": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.0.2.tgz",
-      "integrity": "sha512-zHJcrGmpphnqjUQr+5HhcoInuKxZu3PxGl/NRgTC5gpWp259D0LBPT7k3Lt45r4kruDCMUGpMZVb1s46IZniSQ==",
-      "requires": {
-        "@pixi/canvas-renderer": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.1.3.tgz",
+      "integrity": "sha512-JK6rtqfC2/rnJt1xLPznH2lNH0Jx9f2Py7uh50VM1sqoYrkyAAegenbOdyEzgB35Q4oQji3aBkTsWn2mrwXp/g=="
     },
     "@pixi/app": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.0.2.tgz",
-      "integrity": "sha512-zHCzO0K5jJ48ngbH4FpdYJh1LxuGn9mJSIOF8YorqXFt+3drM9R9/qGGfSGdA9O7rW0O0uIkSndQwPXIlOIsUA==",
-      "requires": {
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2"
-      }
-    },
-    "@pixi/canvas-renderer": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/canvas-renderer/-/canvas-renderer-6.0.2.tgz",
-      "integrity": "sha512-SL3pLxAjEQdVN8Tp/p2svciKeA0DRH7HhlO95frVwxzvG4Z3GGYU39f3ejtCaLPqLGzEJmLND7lbIXh0b+Ornw==",
-      "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.1.3.tgz",
+      "integrity": "sha512-gryDVXuzErRIgY5G2CRQH6fZM7Pk3m1CFEInXEKa4rmVzfwRz+3OeU0YNSnD9atPAS5C2TaAzE4yOSHH2+wESQ=="
     },
     "@pixi/compressed-textures": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.0.2.tgz",
-      "integrity": "sha512-SDuCLn/IEo8j1O+OYPVYy3Dz8+jAXLPdJsMYfs4GOGhsQWZ9js5bfLXWuwr6QRPOXoR3e8zb9qC3co8149pNLg==",
-      "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/loaders": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.1.3.tgz",
+      "integrity": "sha512-FO2B7GhDMlZA0fnpH2PvNOh6ZlRxQoJnNlpjzNw+x1nvF9h3+V6dbFoG9oBC5zAisTfacdfoo1TdT789Oh+kTg=="
     },
     "@pixi/constants": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.0.2.tgz",
-      "integrity": "sha512-4GSVKWr+qtjTj8IpRjXSnpkhF944ybjTSz9FnoqZZJgFxh/+9r53StHEGtKoK+BsSrmqbGzWax9krfc620KcLA=="
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.1.3.tgz",
+      "integrity": "sha512-Qvz/SIxw+dQ6P9niOEdILWX2DQ5FnGA0XZNFLW/3amekzad/+WqHobL+Mg5S6A4/a9mXTnqjyB0BqhhtLfpFkA=="
     },
     "@pixi/core": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.0.2.tgz",
-      "integrity": "sha512-Bz0WQDncrXuLEjU6pX5INrCLd5UorgBfufgysQzncOITIER4sZjAq5R/mCS1M3d4mGFhXZQyMyQK+O4LacWvOQ==",
-      "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/runner": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/ticker": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.1.3.tgz",
+      "integrity": "sha512-UQsR1Q7c+Zcvtu6HrYMidvoyF/j9n3b4WXPh3ojuNV6+ZIvps3rznoZYaIx6foEJNhj7HM9fMObsimGP+FB36A=="
     },
     "@pixi/display": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.0.2.tgz",
-      "integrity": "sha512-5qJxwT07McA7EK2yFhqvAjEJpap4Xa2hUCRDfsxl+Fu1Y3zDNBKI7HB8+mWZdYtSnnh5fJxrrw5lPo4HX7M+6w==",
-      "requires": {
-        "@pixi/math": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.1.3.tgz",
+      "integrity": "sha512-8/GdapJVKfl6PUkxX/Et5zB1aXny+uy353cQX886KJ6dGle82fQAYjIn7I6Xm+JiZWOhWo0N6KE9cjotO0rroA=="
     },
     "@pixi/extract": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.0.2.tgz",
-      "integrity": "sha512-vGrewyLREzZOGAjcJO60s7oDm8ATbJOB5KyxuJXOSmIuhEmP69ohmxt1Rk6W8nfUS5m3gYU2KsY//RfDghHzVA==",
-      "requires": {
-        "@pixi/core": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.1.3.tgz",
+      "integrity": "sha512-yZOsXc9Lh+U59ayl+DoWDPmndrOJj5ft2nzENMAvz2rVEOHQjWxH73qCSP6Wa5VsoINyJLMmV4MTbI+U0SH7GA=="
     },
     "@pixi/filter-alpha": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.0.2.tgz",
-      "integrity": "sha512-fk7I2mCdQLbt9KrxiCd1103okSoNGXnxa1uY1V66jouSo51IXB3PkNEIFbET/cYOM7kKiMui20sYath1g596ag==",
-      "requires": {
-        "@pixi/core": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.1.3.tgz",
+      "integrity": "sha512-eubgEO/qlxQbuPXgwxTZxTBTWjA0EQbrs7TyPqyBK2Wj0eEvimaVQ8u4eiqfMFJCZLnuWDCAPJpP9bMHxBXXpQ=="
     },
     "@pixi/filter-blur": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.0.2.tgz",
-      "integrity": "sha512-FzaIl4l10lOW4+1SWFjLvK3MtH66zBG1SEa/cMUcVOfwZRIrg5pY3X842kZhNErm42yr9N2xBtKwwVBqQRbV8w==",
-      "requires": {
-        "@pixi/core": "6.0.2",
-        "@pixi/settings": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.1.3.tgz",
+      "integrity": "sha512-uo8FHpV+qm4SuXcDnWqZWrznHmLJ3b8ibgLAgi/e8VmwrFiC+EqGa4n4V8J+xtR5P/iA3lT5pRgWw09/xHN3dQ=="
     },
     "@pixi/filter-color-matrix": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.0.2.tgz",
-      "integrity": "sha512-zOKdURfQFBIqknpisG1Ow7BiYD7zVTAHU/Y4aPNBFwcAxET/fKFDB8vJFztO1g0C4v05ivjVXmvAuIAjlXdOhw==",
-      "requires": {
-        "@pixi/core": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.1.3.tgz",
+      "integrity": "sha512-d1pyxmVrGDOrO5pINe+fTspj1NNxiIp2IZ+FGgT7e17xnxjXTvtk4n4KqXAZFS1NCoStImDAV5j+b8Lysdg5jQ=="
     },
     "@pixi/filter-displacement": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.0.2.tgz",
-      "integrity": "sha512-ozhpQ0YkGxsMDzE8u/zTYp0LZ52VBM849iCIqY/WSVZkjeNYB0XhUZdI/7RMDPMVfiQSENimacEpsOgzsOIPSA==",
-      "requires": {
-        "@pixi/core": "6.0.2",
-        "@pixi/math": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.1.3.tgz",
+      "integrity": "sha512-tIXK8vXzb2unMxGmu4gjdlOwddnkHA0IJXFTOF25a5h36v/AHqWwWG4h5G775oPu37UuhuYjeD/j229t0Q9QNQ=="
     },
     "@pixi/filter-fxaa": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.0.2.tgz",
-      "integrity": "sha512-dkX2udy4CqUuAS5yEu3udzdCbpZVdHgoVEksSiFiGzyC17uexkHaunQAgLb2UFGmjbdLT4Vk2FIrgM3+sMWQ3w==",
-      "requires": {
-        "@pixi/core": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.1.3.tgz",
+      "integrity": "sha512-yhKVxX5vFKQz3lxfqAGg4XoajFyIRR8XzWqEHgAsPMFRnIIQIbF25bMRygZj12P61z3vxwqAM/2bn7S46Ii1zQ=="
     },
     "@pixi/filter-noise": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.0.2.tgz",
-      "integrity": "sha512-UnaRYV06qWe7ytBHZ8hK6ZH8Bnqhwtuhoj86pAv0Jhc8EXwcKC2wLT7JDFxBnjB1GwJuWDYnNrQpPsyRQsHNiA==",
-      "requires": {
-        "@pixi/core": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.1.3.tgz",
+      "integrity": "sha512-oVRtcJwbN6VnAnvXZuLEZ0c12JUzporao5AziXgRAUjTMA3bFVE0/7Dx193Kx/l6UAasmzhWQctuv6NMxy5Efw=="
     },
     "@pixi/graphics": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.0.2.tgz",
-      "integrity": "sha512-/hONnNsWIo8O/0yQf2voBRi0aLnt7RXHXiYLb1d0bMkfYVHbn6r+TYZsz/mjOC1MRW+B0Bkh5ZxRWOgF3IpCiA==",
-      "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/sprite": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.1.3.tgz",
+      "integrity": "sha512-e5O47yECRp5WXWIvKhLDQKpiak7CfIqJzuTuQIyE7jXp8QiJNw+aoWNlJEd4ksKbsDkP3EE39CxlmiaBpxNL3w=="
     },
     "@pixi/interaction": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.0.2.tgz",
-      "integrity": "sha512-YRT1reJXISgAf1+lRECpchR7+MUcGA/vdC612oG0fbrONCI0r1jMwMjdEcTnuMzZrzfSGL6yz0pkhIjWMjuY0g==",
-      "requires": {
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/ticker": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.1.3.tgz",
+      "integrity": "sha512-ju3fE/KnO6KZChnZzZAdY6bfjlSh7/igZcVcd/MZRkAdNozx4QoN5sYmwrcvTvA5llMYaThSIRWgIHQiSlbOfQ=="
     },
     "@pixi/loaders": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.0.2.tgz",
-      "integrity": "sha512-ir71du5YOoH/NW8/rNwQ5br+YCVcKWUAltsUaQfTCMLjPzaT8nHtsBiy/krQIGNus179l1h7NfGrSOK/RU936Q==",
-      "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/utils": "6.0.2",
-        "resource-loader": "^3.0.1"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.1.3.tgz",
+      "integrity": "sha512-qOvy72bsVGzCmWyoofm6dm1l//hd+bJneidngplwsovpqnnyMfuewCpQjeLRL6rLqcHR40V1+Qo4iJ+ElMdVZQ=="
     },
     "@pixi/math": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.0.2.tgz",
-      "integrity": "sha512-eA4VmqkWTUSRl1iYIu3sCitbg8+QfohU0Zk/61J1s0pzWtLjMECkrlcwiFfCxwNU7MhkOATQ53dxgmNtBa77zw=="
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.1.3.tgz",
+      "integrity": "sha512-1bLZeHpG38Bz6TESwxayNbL7tztOd7gpZDXS5OiBB9n8SFZeKlWfRQ/aJrvjoBz2qsZf9gGeVKsHpC/FJz0qnA=="
     },
     "@pixi/mesh": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.0.2.tgz",
-      "integrity": "sha512-Sc3VrB7/MQ4/Ju86Cks43pJlw6bH0o/SXm/UgIkW7B2cYQMdffcWwt3bOvdyeiChNJWN6308m9VtU0Dx+5xalA==",
-      "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.1.3.tgz",
+      "integrity": "sha512-TF9eKNQdowozVOr4G05+Auku2EK8XwDXKYVvMYvt6Tsn2DLSrRhWl7xYyj4EuTjW/4eaP/c2QqY18cEMoMtJiQ=="
     },
     "@pixi/mesh-extras": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.0.2.tgz",
-      "integrity": "sha512-Q2O3/MR5ghMx95N2DnvYbyDL6aK9fU5cxLy6nEAd/i4iNyBA/XIfC7iB6WY207OyF9PIjPedT5Ha1SSSiujhAA==",
-      "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/mesh": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.1.3.tgz",
+      "integrity": "sha512-HuTV8SkTQZDU1bmHmJWRo+4Hiz89oCuOonE3ckfqsoAoULfImgU72qqNIq7Vxmnu3kXoXAwV+fvOl49OzWl4+w=="
     },
     "@pixi/mixin-cache-as-bitmap": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.0.2.tgz",
-      "integrity": "sha512-GBS/s1sf01AWmWBiFD9ppx/20EZMGYvJ2vq/fK/7jmTRA1gTJVI9UA/Suhx3n2KVe7szRDHBAgKKuMjC0W4q7w==",
-      "requires": {
-        "@pixi/canvas-renderer": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/sprite": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.1.3.tgz",
+      "integrity": "sha512-mEa0kn3Mou3KhbAUpaGnvmPz/ifI/41af1N6kVcTz1V8cu4BI/f74xLv5pKkQtp+xzWlquGo/2z9urkrRFD6qA=="
     },
     "@pixi/mixin-get-child-by-name": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.0.2.tgz",
-      "integrity": "sha512-qQ+cqOXX50FG3DyuOS69iVc9uOox93ARJoBoh1d3aYwHMUg45oBTyX6xv3suquvPTDcLnKGrJeiHQ/c/xw7tRw==",
-      "requires": {
-        "@pixi/display": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.1.3.tgz",
+      "integrity": "sha512-HHrnA1MtsMSyW0lOnBlklHp7j3JGYHIyick4b8F8p8eKqOFiAVdLzf4tmX/fKF4zs6i7DuYKE8G9Z7vpAhyrFg=="
     },
     "@pixi/mixin-get-global-position": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.0.2.tgz",
-      "integrity": "sha512-waO1D/asjNorJpE+hdJqCg1gnfqOVIUf2mZmKWfS4jW/OPvhbAR1pX6uXP2uZ6yLoK/Ft94x9faMjuDeqxMdFg==",
-      "requires": {
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.1.3.tgz",
+      "integrity": "sha512-XqhEyViMlGOS+p2LKW2tFjQy4ghbARKriwgY10MGvNApHHZbUDL3VKM1EmR6F2Xj8PPmycWRw/0oBu148O2KhQ=="
     },
-    "@pixi/particles": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-6.0.2.tgz",
-      "integrity": "sha512-Z0vAjqmCGXrdwBmdiC7I4Flv0QQ0q4GxC1lqymT58KhA//GiZOLYp0FuK5RojslLrUu7w5MAfUWwLq7gruu2cQ==",
-      "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+    "@pixi/particle-container": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.1.3.tgz",
+      "integrity": "sha512-pZqRRL5Yx2Yy30cdjsNEXRpTfl1WEf640ZLVHX2+fcKcWftPJaIXQZR+0aLvijyWF3VA4O/r/8IxhYgiMkqAUQ=="
     },
     "@pixi/polyfill": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.0.2.tgz",
-      "integrity": "sha512-PD+d3kGPPKoYgkSQ/xT8U3y12T4StkcpCK6QfFy6k+dkWHzGcQI1aE46Vw6tZ+ZkFi5nRUTNk9C3VlwWt/Fdfw==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.1.3.tgz",
+      "integrity": "sha512-e+g2sHK/ORKDOrhJ86zZgdMSkQNzKdkaMw/UUFZ5wEUJgltoqF7H0zwNVPPO/1m7hfrN02PBMinYtXM+qFdY/A==",
       "requires": {
         "object-assign": "^4.1.1",
         "promise-polyfill": "^8.2.0"
       }
     },
     "@pixi/prepare": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.0.2.tgz",
-      "integrity": "sha512-bmVE/6qV7Psd3EhumLdeAH7MmU3VpuUcnbyDhrmrJrUmfbqrXiMApCLqGSYjMHQI/abZwFQ0vMgDQhx9dfG8wA==",
-      "requires": {
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/graphics": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/text": "6.0.2",
-        "@pixi/ticker": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.1.3.tgz",
+      "integrity": "sha512-zjv81fPJjdQyWGCbA9Ij04GfwJUYA3j6/vFyJFaDKVMqEWzNDJwu40G00P23BXh3F5dYL638EXvyLYDQavjseg=="
     },
     "@pixi/runner": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.0.2.tgz",
-      "integrity": "sha512-HcaDuwT+kconUZJh9gzGy166R/0hWkgXpLX0mqUYo5qPKmhiC+balJsiha6IIV6Ckg5c5IX2GQBSkXJrEDlOMg=="
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.1.3.tgz",
+      "integrity": "sha512-hJw7O9enlei7Cp5/j2REKuUjvyyC4BGqmVycmt01jTYyphRYMNQgyF+OjwrL7nidZMXnCVzfNKWi8e5+c4wssg=="
     },
     "@pixi/settings": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.0.2.tgz",
-      "integrity": "sha512-hZMZIKDsqpf2qtVAnZvemGcFw1ujkZb/r4nVn4/hYeyZLK63I5IpQKEPPK9NMicTM697V+BRoMbWqbrlubiLKw==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.1.3.tgz",
+      "integrity": "sha512-laKwS4/R+bTQokKIeMeMO4orvSNTMWUpNRXJbDq7N29bCrA5pT6BW+LNZ+4gJs4TFK/s9bmP/xU5BlPVKHRoyg==",
       "requires": {
         "ismobilejs": "^1.1.0"
       }
     },
     "@pixi/sprite": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.0.2.tgz",
-      "integrity": "sha512-I9FHX0zxvfVg/L6hZVRX9kpsdbbxLu9KhN8kdJmDR+RGxuoxGrnboTx5VgT3AW0rYJvwp47VneQTKVVMjat11A==",
-      "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.1.3.tgz",
+      "integrity": "sha512-TzvqeRV+bbxFbucR74c28wcDsCbXic+5dONM+fy31ejAIraKbigzKbgHxH6opgLEMMh5APzmJPlwntYdEUGSXQ=="
     },
     "@pixi/sprite-animated": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.0.2.tgz",
-      "integrity": "sha512-OSINySJ1uk/iaD4Yk/3czRlitTMVIEgzgvqzSZL+GcqHqzc3lW/BpZ31+so+W/4Yv7KckzBJdB++GvsAfAU0kA==",
-      "requires": {
-        "@pixi/core": "6.0.2",
-        "@pixi/sprite": "6.0.2",
-        "@pixi/ticker": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.1.3.tgz",
+      "integrity": "sha512-COrFkmcMPxyv3zGRJJrNB2nOdaeDEOYTkbxUcNxMSJ7eT3O3PUX5XEvfOW7bl2zHkt8XraIQ66uwWychqGHx7Q=="
     },
     "@pixi/sprite-tiling": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.0.2.tgz",
-      "integrity": "sha512-tauohq//qEZirTM5A6pLKUIUgBPp1qTxjrI4lpFp4scalehAdR04dPe3a9JMr7uwmPiskQIB5/LZX7sMtl3jpg==",
-      "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/sprite": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.1.3.tgz",
+      "integrity": "sha512-om+RrModhNFljb8C1fhpGKtgt5k5AW9gCjFfeBPN+5pVdVjtc/luyO2Cbubpeow9YQldrUZri9it63GBo07Cfw=="
     },
     "@pixi/spritesheet": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.0.2.tgz",
-      "integrity": "sha512-gWVxx0uWKaNtcj1beLZw0vvogDgmerct+oSA0pU6A3b20pDMrAPc90EuOEOOQ/xxxrHfpIY00IIXsUmAmmA0Zg==",
-      "requires": {
-        "@pixi/core": "6.0.2",
-        "@pixi/loaders": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.1.3.tgz",
+      "integrity": "sha512-QUqAYUzn/+0JlzrLo7ASIFzJSteGZuNMxKwyFL29JtttUIjdJlXe3+jrfUMAu6gewYd9HVYkXJ0ODhH8PH6KpA=="
     },
     "@pixi/text": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.0.2.tgz",
-      "integrity": "sha512-XBhiwLeuL8dBsPwXMDOq9O0JxZcOA2l0aOnFs2O2fZPLL4gkvyquZA+s95C6bGZMR+6j0xtFIQDCsBQCZl1A/g==",
-      "requires": {
-        "@pixi/core": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/sprite": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.1.3.tgz",
+      "integrity": "sha512-R0D3cbwwLbQOfobja4NGhq0bF7biCfNE3PXsOmTEsWOroVJqUexIob5XZXoT9Avy3B8nlrB2Hyl5imIQx60jFw=="
     },
     "@pixi/text-bitmap": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.0.2.tgz",
-      "integrity": "sha512-wT3JUp/Y1+B979UpIMibV3Cir0Tb1oi5Sc1r6FPr51KUfFxHMj6Q7+OV1YxJvSMoaKLK6efImfMXGKAKYtVXMQ==",
-      "requires": {
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/loaders": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/mesh": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/text": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.1.3.tgz",
+      "integrity": "sha512-x46qOVoosl67dBrG3mgd2eQx3A9NTxWUnzgRpk5vsNfLLNRu6XlM+YoscRMuHT5sLEEBLewjcVxzAAkrSW45eQ=="
     },
     "@pixi/ticker": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.0.2.tgz",
-      "integrity": "sha512-oBZTfId0D+hDbDCaYvREclI7jvIAmcaxd7iaOPcELHcPPyJ+ym+4hggsXSIchXeeFYasLjI5bfqJPzzL6IasTg==",
-      "requires": {
-        "@pixi/settings": "6.0.2"
-      }
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.1.3.tgz",
+      "integrity": "sha512-ZSuhe5HrmkDoqSIZjETUGYCQr/EbtDQGngq0LQLAgblyhAJbi4p/B3uf2XGfRNZ7Tdxdl0j81BmUqBEu2+DeoA=="
     },
     "@pixi/utils": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.0.2.tgz",
-      "integrity": "sha512-jx3ZYJ29mTJSqBPQbDUPPorsPXiGOQzL6IIW5vwE05LekYmwocR8b48vLYKdbr8XdyOQ7Eqe43PodiwCLjuWvA==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.1.3.tgz",
+      "integrity": "sha512-05mm9TBbpYorYO3ALC4CVgR5K6sA/0uhnwE/Zl4ZhNJZN699LrIr0OWFQhxhySeGUPMDaizeEZpn2rhx+CYYpg==",
       "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/settings": "6.0.2",
         "@types/earcut": "^2.1.0",
         "earcut": "^2.2.2",
         "eventemitter3": "^3.1.0",
@@ -7618,9 +7437,9 @@
       }
     },
     "earcut": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.2.tgz",
-      "integrity": "sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ=="
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
+      "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -11274,11 +11093,6 @@
         }
       }
     },
-    "mini-signals": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mini-signals/-/mini-signals-1.2.0.tgz",
-      "integrity": "sha1-RbCAE8X65RokqhqTXNMXye1yHXQ="
-    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -12436,11 +12250,6 @@
       "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
       "dev": true
     },
-    "parse-uri": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/parse-uri/-/parse-uri-1.0.3.tgz",
-      "integrity": "sha512-upMnGxNcm+45So85HoguwZTVZI9u11i36DdxJfGF2HYWS2eh3TIx7+/tTi7qrEq15qzGkVhsKjesau+kCk48pA=="
-    },
     "parse5": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
@@ -12611,45 +12420,45 @@
       "dev": true
     },
     "pixi.js": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.0.2.tgz",
-      "integrity": "sha512-ioH2+TxyWMwY+nlOgopxfHBBOpB2Wp79LBNCXPP8dIFWH6q70IAKAL++39aK7+MyLvdqwQ+tSnIWuAMNpKPJCw==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.1.3.tgz",
+      "integrity": "sha512-h8Y/YVgP4CSPoUQvXaQvQf5GyQxi0b1NtVD38bZQsrX4CQ3r85jBU+zPyHN0fAcvhCB+nNvdD2sEwhhqkNsuSw==",
       "requires": {
-        "@pixi/accessibility": "6.0.2",
-        "@pixi/app": "6.0.2",
-        "@pixi/compressed-textures": "6.0.2",
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/extract": "6.0.2",
-        "@pixi/filter-alpha": "6.0.2",
-        "@pixi/filter-blur": "6.0.2",
-        "@pixi/filter-color-matrix": "6.0.2",
-        "@pixi/filter-displacement": "6.0.2",
-        "@pixi/filter-fxaa": "6.0.2",
-        "@pixi/filter-noise": "6.0.2",
-        "@pixi/graphics": "6.0.2",
-        "@pixi/interaction": "6.0.2",
-        "@pixi/loaders": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/mesh": "6.0.2",
-        "@pixi/mesh-extras": "6.0.2",
-        "@pixi/mixin-cache-as-bitmap": "6.0.2",
-        "@pixi/mixin-get-child-by-name": "6.0.2",
-        "@pixi/mixin-get-global-position": "6.0.2",
-        "@pixi/particles": "6.0.2",
-        "@pixi/polyfill": "6.0.2",
-        "@pixi/prepare": "6.0.2",
-        "@pixi/runner": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/sprite": "6.0.2",
-        "@pixi/sprite-animated": "6.0.2",
-        "@pixi/sprite-tiling": "6.0.2",
-        "@pixi/spritesheet": "6.0.2",
-        "@pixi/text": "6.0.2",
-        "@pixi/text-bitmap": "6.0.2",
-        "@pixi/ticker": "6.0.2",
-        "@pixi/utils": "6.0.2"
+        "@pixi/accessibility": "6.1.3",
+        "@pixi/app": "6.1.3",
+        "@pixi/compressed-textures": "6.1.3",
+        "@pixi/constants": "6.1.3",
+        "@pixi/core": "6.1.3",
+        "@pixi/display": "6.1.3",
+        "@pixi/extract": "6.1.3",
+        "@pixi/filter-alpha": "6.1.3",
+        "@pixi/filter-blur": "6.1.3",
+        "@pixi/filter-color-matrix": "6.1.3",
+        "@pixi/filter-displacement": "6.1.3",
+        "@pixi/filter-fxaa": "6.1.3",
+        "@pixi/filter-noise": "6.1.3",
+        "@pixi/graphics": "6.1.3",
+        "@pixi/interaction": "6.1.3",
+        "@pixi/loaders": "6.1.3",
+        "@pixi/math": "6.1.3",
+        "@pixi/mesh": "6.1.3",
+        "@pixi/mesh-extras": "6.1.3",
+        "@pixi/mixin-cache-as-bitmap": "6.1.3",
+        "@pixi/mixin-get-child-by-name": "6.1.3",
+        "@pixi/mixin-get-global-position": "6.1.3",
+        "@pixi/particle-container": "6.1.3",
+        "@pixi/polyfill": "6.1.3",
+        "@pixi/prepare": "6.1.3",
+        "@pixi/runner": "6.1.3",
+        "@pixi/settings": "6.1.3",
+        "@pixi/sprite": "6.1.3",
+        "@pixi/sprite-animated": "6.1.3",
+        "@pixi/sprite-tiling": "6.1.3",
+        "@pixi/spritesheet": "6.1.3",
+        "@pixi/text": "6.1.3",
+        "@pixi/text-bitmap": "6.1.3",
+        "@pixi/ticker": "6.1.3",
+        "@pixi/utils": "6.1.3"
       }
     },
     "pkg-dir": {
@@ -13457,15 +13266,6 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
-    },
-    "resource-loader": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/resource-loader/-/resource-loader-3.0.1.tgz",
-      "integrity": "sha512-fBuCRbEHdLCI1eglzQhUv9Rrdcmqkydr1r6uHE2cYHvRBrcLXeSmbE/qI/urFt8rPr/IGxir3BUwM5kUK8XoyA==",
-      "requires": {
-        "mini-signals": "^1.2.0",
-        "parse-uri": "^1.0.0"
-      }
     },
     "responselike": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emblaze",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Interactive Jupyter notebook widget for visually comparing embeddings",
   "keywords": [
     "jupyter",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "d3": "^6.7.0",
     "d3-svg-legend": "^2.25.6",
     "mathjs": "^9.3.2",
-    "pixi.js": "^6.0.2"
+    "pixi.js": "^6.1.3"
   },
   "devDependencies": {
     "@babel/core": "^7.13.15",


### PR DESCRIPTION
WebGL in Safari 15 breaks the current shader code. This PR fixes that issue by updating the shaders to use GLSL version 300, and also fixes an issue loading `ImageThumbnails`.