### PR TITLE
Handle multiple neighbor sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,15 @@ X, Y = ...
 
 # Represent the high-dimensional embedding
 emb = emblaze.Embedding({Field.POSITION: X, Field.COLOR: Y})
-# Compute nearest neighbors in the high-D space
-emb.compute_neighbors(metric='euclidean')
+# Compute nearest neighbors in the high-D space (for display)
+emb.compute_neighbors(metric='cosine')
 
 # Generate UMAP 2D representations - you can pass UMAP parameters to project()
 variants = emblaze.EmbeddingSet([
     emb.project(method=ProjectionTechnique.UMAP) for _ in range(10)
 ])
+# Compute neighbors again (to indicate that we want to compare projections)
+variants.compute_neighbors(metric='euclidean')
 
 w = emblaze.Viewer(embeddings=variants)
 w
@@ -76,7 +78,7 @@ embeddings = emblaze.EmbeddingSet([
     emblaze.Embedding({Field.POSITION: X, Field.COLOR: Y}, label=emb_name)
     for X, emb_name in zip(Xs, embedding_names)
 ])
-embeddings.compute_neighbors()
+embeddings.compute_neighbors(metric='cosine')
 
 # Make aligned UMAP
 reduced = embeddings.project(method=ProjectionTechnique.ALIGNED_UMAP)

--- a/emblaze/datasets.py
+++ b/emblaze/datasets.py
@@ -532,8 +532,8 @@ class EmbeddingSet:
             "frameLabels": [emb.label or "Frame {}".format(i) for i, emb in enumerate(self.embeddings)]
         }
 
-    @staticmethod
-    def from_json(data, metric='euclidean'):
+    @classmethod
+    def from_json(cls, data, metric='euclidean'):
         """
         Builds an EmbeddingSet from a JSON object. The provided object should
         contain a "data" field containing frames, and optionally a "frameLabels"
@@ -542,4 +542,32 @@ class EmbeddingSet:
         assert "data" in data, "JSON object must contain a 'data' field"
         labels = data.get("frameLabels", [None for _ in range(len(data["data"]))])
         embs = [Embedding.from_json(frame, label=label, metric=metric) for frame, label in zip(data["data"], labels)]
-        return EmbeddingSet(embs, align=False)
+        return cls(embs, align=False)
+    
+    def save(self, file_path_or_buffer):
+        """
+        Save this EmbeddingSet object to the given file path or file-like object
+        (in JSON format).
+        """
+        if isinstance(file_path_or_buffer, str):
+            # File path
+            with open(file_path_or_buffer, 'w') as file:
+                json.dump(self.to_json(), file)
+        else:
+            # File object
+            json.dump(self.to_json(), file_path_or_buffer)
+            
+    @classmethod
+    def load(cls, file_path_or_buffer, metric='euclidean'):
+        """
+        Load the EmbeddingSet from the given file path or file-like object
+        containing JSON data.
+        """
+        if isinstance(file_path_or_buffer, str):
+            # File path
+            with open(file_path_or_buffer, 'r') as file:
+                return cls.from_json(json.load(file), metric=metric)
+        else:
+            # File object
+            return cls.from_json(json.load(file_path_or_buffer), metric=metric)
+        

--- a/emblaze/frame_colors.py
+++ b/emblaze/frame_colors.py
@@ -109,9 +109,9 @@ def compute_colors(frames, ids_of_interest=None, scale_factor=1.0):
     outer_jaccard_distances = np.zeros((len(frames), len(frames)))
     inner_jaccard_distances = np.zeros((len(frames), len(frames)))
     for i in range(len(frames)):
-        frame_1_neighbors = frames[i].neighbors[distance_sample]
+        frame_1_neighbors = frames[i].get_recent_neighbors()[distance_sample]
         for j in range(len(frames)):
-            frame_2_neighbors = frames[j].neighbors[distance_sample]
+            frame_2_neighbors = frames[j].get_recent_neighbors()[distance_sample]
             # If the id set is the entire frame, there will be no outer neighbors
             # so we can just leave this at zero
             if ids_of_interest is not None and len(ids_of_interest):

--- a/emblaze/frame_colors.py
+++ b/emblaze/frame_colors.py
@@ -109,9 +109,9 @@ def compute_colors(frames, ids_of_interest=None, scale_factor=1.0):
     outer_jaccard_distances = np.zeros((len(frames), len(frames)))
     inner_jaccard_distances = np.zeros((len(frames), len(frames)))
     for i in range(len(frames)):
-        frame_1_neighbors = frames[i].field(Field.NEIGHBORS, distance_sample)
+        frame_1_neighbors = frames[i].neighbors[distance_sample]
         for j in range(len(frames)):
-            frame_2_neighbors = frames[j].field(Field.NEIGHBORS, distance_sample)
+            frame_2_neighbors = frames[j].neighbors[distance_sample]
             # If the id set is the entire frame, there will be no outer neighbors
             # so we can just leave this at zero
             if ids_of_interest is not None and len(ids_of_interest):

--- a/emblaze/neighbors.py
+++ b/emblaze/neighbors.py
@@ -1,0 +1,171 @@
+import numpy as np
+from sklearn.neighbors import NearestNeighbors
+from .utils import *
+
+class Neighbors:
+    """
+    An object representing a serializable set of nearest neighbors within an
+    embedding. The Neighbors object simply stores a matrix of integer IDs, where rows
+    correspond to points in the embedding and columns are IDs of neighbors in
+    order of proximity to each point.
+    """
+    def __init__(self, values, ids=None, metric='euclidean', n_neighbors=100, clf=None):
+        """
+        pos: Matrix of n x D vectors indicating high-dimensional positions
+        ids: If supplied, a list of IDs for the points in the matrix
+        """
+        super().__init__()
+        self.values = values
+        self.ids = ids
+        self._id_index = {id: i for i, id in enumerate(self.ids)}
+        self.metric = metric
+        self.n_neighbors = n_neighbors
+        self.clf = clf
+    
+    @classmethod
+    def compute(cls, pos, ids=None, metric='euclidean', n_neighbors=100):
+        ids = ids if ids is not None else np.arange(len(pos))
+        neighbor_clf = NearestNeighbors(metric=metric,
+                                        n_neighbors=n_neighbors + 1).fit(pos)
+        _, neigh_indexes = neighbor_clf.kneighbors(pos)
+        
+        return cls(ids[neigh_indexes[:,1:]], ids=ids, metric=metric, n_neighbors=n_neighbors, clf=neighbor_clf)
+        
+    def index(self, id_vals):
+        """
+        Returns the index(es) of the given IDs.
+        """
+        if isinstance(id_vals, (list, np.ndarray, set)):
+            return [self._id_index[int(id_val)] for id_val in id_vals]
+        else:
+            return self._id_index[int(id_vals)]
+
+    def __getitem__(self, ids):
+        """ids can be a single ID or a sequence of IDs"""
+        if ids is None: return self.values
+        return self.values[self.index(ids)]
+    
+    def __eq__(self, other):
+        if isinstance(other, NeighborSet): return other == self
+        if not isinstance(other, Neighbors): return False
+        return np.allclose(self.ids, other.ids) and np.allclose(self.values, other.values)
+    
+    def __ne__(self, other):
+        return not (self == other)
+        
+    def __len__(self):
+        return len(self.values)
+    
+    def calculate_neighbors(self, pos, return_distance=True, n_neighbors=None):
+        if self.clf is None:
+            raise ValueError(
+                ("Cannot compute neighbors because the Neighbors was not "
+                 "initialized with a neighbor classifier - was it deserialized "
+                 "from JSON without saving the original coordinates or "
+                 "concatenated to another Neighbors?"))
+        neigh_dists, neigh_indexes = self.clf.kneighbors(pos, n_neighbors=n_neighbors or self.n_neighbors)
+        if return_distance:
+            return neigh_dists, neigh_indexes
+        return neigh_indexes
+    
+    def concat(self, other):
+        """Concatenates the two Neighbors together, discarding the original 
+        classifier."""
+        assert not (set(self.ids.tolist()) & set(other.ids.tolist())), "Cannot concatenate Neighbors objects with overlapping ID values"
+        assert self.metric == other.metric, "Cannot concatenate Neighbors objects with different metrics"
+        return Neighbors(
+            np.concatenate(self.values, other.values),
+            ids=np.concatenate(self.ids, other.ids),
+            metric=self.metric,
+            n_neighbors = max(self.n_neighbors, other.n_neighbors)
+        )
+    
+    def to_json(self, compressed=True, num_neighbors=None):
+        """Serializes the neighbors to a JSON object."""
+        result = {}
+        result["metric"] = self.metric
+        result["n_neighbors"] = self.n_neighbors
+        
+        neighbors = self.values
+        if num_neighbors is not None:
+            neighbors = neighbors[:,:min(num_neighbors, neighbors.shape[1])]
+            
+        if compressed:
+            result["_format"] = "compressed"
+            # Specify the type name that will be used to encode the point IDs.
+            # This is important because the highlight array takes up the bulk
+            # of the space when transferring to file/widget.
+            dtype, type_name = choose_integer_type(self.ids)
+            result["_idtype"] = type_name
+            result["_length"] = len(self)
+            result["ids"] = encode_numerical_array(self.ids, dtype)
+            
+            result["neighbors"] = encode_numerical_array(neighbors.flatten(),
+                                                            astype=dtype,
+                                                            interval=neighbors.shape[1])
+        else:
+            result["_format"] = "expanded"
+            result["neighbors"] = {}
+            indexes = self.index(self.ids)
+            for id_val, index in zip(self.ids, indexes):
+                result["neighbors"][id_val] = neighbors[index].tolist()
+        return result
+    
+    @classmethod
+    def from_json(cls, data):
+        if data.get("_format", "expanded") == "compressed":
+            dtype = np.dtype(data["_idtype"])
+            ids = decode_numerical_array(data["ids"], dtype)
+            neighbors = decode_numerical_array(data["neighbors"], dtype)
+        else:
+            neighbor_dict = data["neighbors"]
+            try:
+                ids = [int(id_val) for id_val in list(neighbor_dict.keys())]
+                neighbor_dict = {int(k): v for k, v in neighbor_dict.items()}
+            except:
+                ids = list(neighbor_dict.keys())
+            ids = sorted(ids)
+            neighbors = np.array([neighbor_dict[id_val] for id_val in ids])
+                
+        return cls(neighbors, ids=ids, metric=data["metric"], n_neighbors=data["n_neighbors"])
+
+class NeighborSet:
+    """
+    An object representing a serializable collection of Neighbors objects.
+    """
+    def __init__(self, neighbor_objects):
+        super().__init__()
+        self._neighbors = neighbor_objects
+        
+    def __getitem__(self, slice):
+        return self._neighbors[slice]
+    
+    def __setitem__(self, slice, val):
+        self._neighbors[slice] = val
+        
+    def __len__(self):
+        return len(self._neighbors)
+    
+    def __iter__(self):
+        return iter(self._neighbors)
+    
+    def __eq__(self, other):
+        if isinstance(other, NeighborSet):
+            return len(other) == len(self) and all(n1 == n2 for n1, n2 in zip(self, other))
+        elif isinstance(other, Neighbors):
+            return all(n1 == other for n1 in self)
+        return False
+    
+    def __ne__(self, other):
+        return not (self == other)
+    
+    def to_json(self, compressed=True, num_neighbors=None):
+        """
+        Serializes the list of Neighbors objects to JSON.
+        """
+        return [n.to_json(compressed=compressed, num_neighbors=num_neighbors)
+                for n in self]
+        
+    @classmethod
+    def from_json(cls, data):
+        return [Neighbors.from_json(d) for d in data]

--- a/emblaze/neighbors.py
+++ b/emblaze/neighbors.py
@@ -169,3 +169,8 @@ class NeighborSet:
     @classmethod
     def from_json(cls, data):
         return [Neighbors.from_json(d) for d in data]
+    
+    def identical(self):
+        """Returns True if all Neighbors objects within this NeighborSet are equal to each other."""
+        if len(self) == 0: return True
+        return all(n == self[0] for n in self)

--- a/emblaze/recommender.py
+++ b/emblaze/recommender.py
@@ -67,8 +67,8 @@ class SelectionRecommender:
         """
         frame_1 = self.embeddings[idx_1]
         frame_2 = self.embeddings[idx_2]
-        frame_1_neighbors = frame_1.field(Field.NEIGHBORS, ids=filter_points or None)
-        frame_2_neighbors = frame_2.field(Field.NEIGHBORS, ids=filter_points or None)
+        frame_1_neighbors = frame_1.neighbors[filter_points or None]
+        frame_2_neighbors = frame_2.neighbors[filter_points or None]
         gained_ids = [set(frame_2_neighbors[i]) - set(frame_1_neighbors[i]) for i in range(len(filter_points or frame_1))]
         lost_ids = [set(frame_1_neighbors[i]) - set(frame_2_neighbors[i]) for i in range(len(filter_points or frame_1))]
 
@@ -79,15 +79,15 @@ class SelectionRecommender:
         Computes the consistency between the neighbors for the given set of IDs 
         in the given frame.
         """
-        return (np.sum(1 - self._pairwise_jaccard_distances(frame.field(Field.NEIGHBORS, ids=ids))) - len(ids)) / (len(ids) * (len(ids) - 1))
+        return (np.sum(1 - self._pairwise_jaccard_distances(frame.neighbors[ids])) - len(ids)) / (len(ids) * (len(ids) - 1))
         
     def _inner_change_score(self, ids, frame_1, frame_2):
         """
         Computes the inverse intersection of the neighbor sets in the given
         two frames.
         """
-        return np.mean(inverse_intersection(frame_1.field(Field.NEIGHBORS, ids=ids),
-                                            frame_2.field(Field.NEIGHBORS, ids=ids),
+        return np.mean(inverse_intersection(frame_1.neighbors[ids],
+                                            frame_2.neighbors[ids],
                                             List(ids),
                                             False))
         
@@ -180,7 +180,7 @@ class SelectionRecommender:
                 
             # Assemble a list of candidates
             if ids_of_interest is not None:
-                neighbor_ids = set([n for n in self.embeddings[frame_key[0]].field(Field.NEIGHBORS, ids_of_interest)[:,:NUM_NEIGHBORS_FOR_SEARCH].flatten()])
+                neighbor_ids = set([n for n in self.embeddings[frame_key[0]].neighbors[ids_of_interest][:,:NUM_NEIGHBORS_FOR_SEARCH].flatten()])
             else:
                 neighbor_ids = None    
 

--- a/emblaze/recommender.py
+++ b/emblaze/recommender.py
@@ -67,8 +67,8 @@ class SelectionRecommender:
         """
         frame_1 = self.embeddings[idx_1]
         frame_2 = self.embeddings[idx_2]
-        frame_1_neighbors = frame_1.neighbors[filter_points or None]
-        frame_2_neighbors = frame_2.neighbors[filter_points or None]
+        frame_1_neighbors = frame_1.get_recent_neighbors()[filter_points or None]
+        frame_2_neighbors = frame_2.get_recent_neighbors()[filter_points or None]
         gained_ids = [set(frame_2_neighbors[i]) - set(frame_1_neighbors[i]) for i in range(len(filter_points or frame_1))]
         lost_ids = [set(frame_1_neighbors[i]) - set(frame_2_neighbors[i]) for i in range(len(filter_points or frame_1))]
 
@@ -79,15 +79,15 @@ class SelectionRecommender:
         Computes the consistency between the neighbors for the given set of IDs 
         in the given frame.
         """
-        return (np.sum(1 - self._pairwise_jaccard_distances(frame.neighbors[ids])) - len(ids)) / (len(ids) * (len(ids) - 1))
+        return (np.sum(1 - self._pairwise_jaccard_distances(frame.get_recent_neighbors()[ids])) - len(ids)) / (len(ids) * (len(ids) - 1))
         
     def _inner_change_score(self, ids, frame_1, frame_2):
         """
         Computes the inverse intersection of the neighbor sets in the given
         two frames.
         """
-        return np.mean(inverse_intersection(frame_1.neighbors[ids],
-                                            frame_2.neighbors[ids],
+        return np.mean(inverse_intersection(frame_1.get_recent_neighbors()[ids],
+                                            frame_2.get_recent_neighbors()[ids],
                                             List(ids),
                                             False))
         
@@ -180,7 +180,7 @@ class SelectionRecommender:
                 
             # Assemble a list of candidates
             if ids_of_interest is not None:
-                neighbor_ids = set([n for n in self.embeddings[frame_key[0]].neighbors[ids_of_interest][:,:NUM_NEIGHBORS_FOR_SEARCH].flatten()])
+                neighbor_ids = set([n for n in self.embeddings[frame_key[0]].get_recent_neighbors()[ids_of_interest][:,:NUM_NEIGHBORS_FOR_SEARCH].flatten()])
             else:
                 neighbor_ids = None    
 

--- a/emblaze/utils.py
+++ b/emblaze/utils.py
@@ -14,7 +14,6 @@ class Field:
     POSITION = "position"
     COLOR = "color"
     RADIUS = "r"
-    NEIGHBORS = "highlight"
     ALPHA = "alpha"
     
     # Thumbnail fields
@@ -174,6 +173,19 @@ def choose_integer_type(values):
         return np.uint16, "u2"
     return np.uint8, "u1"
     
+def _detect_numerical_sequence(arr):
+    """
+    Detects a numerical sequence to compress large arrays of integer IDs when
+    they are regularly spaced. If a sequence is detected, returns the start, end,
+    and step such that using np.arange() with these three arguments yields the
+    appropriate result. If no sequence is detected, returns None.
+    """
+    diffs = arr[1:] - arr[:-1]
+    if np.allclose(diffs, diffs[0]):
+        step = diffs[0]
+        return (arr[0], arr[-1] + step, step)
+    return None
+    
 def encode_numerical_array(arr, astype=np.float32, positions=None, interval=None):
     """
     Encodes the given numpy array into a base64 representation for fast transfer
@@ -187,6 +199,10 @@ def encode_numerical_array(arr, astype=np.float32, positions=None, interval=None
     If interval is not None, it is passed into the result object directly (and
     signifies the same as positions, but with a regularly spaced interval).
     """
+    # TODO support saving arrays as numerical sequence metadata
+    # sequence_info = _detect_numerical_sequence(arr)
+    # if sequence_info is not None:
+    #     result = { ""}
     result = { "values": base64.b64encode(arr.astype(astype)).decode('ascii') }
     if positions is not None:
         result["positions"] = base64.b64encode(positions.astype(np.int32)).decode('ascii')

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -24,6 +24,7 @@
   import { ThumbnailProvider } from './visualization/models/thumbnails';
 
   let data = syncValue(model, 'data', {});
+  let neighborData = syncValue(model, 'neighborData', []);
   let isLoading = syncValue(model, 'isLoading', true);
   let loadingMessage = syncValue(model, 'loadingMessage', '');
 
@@ -61,7 +62,7 @@
 
   $: updateDataset($data);
 
-  function updateDataset(rawData) {
+  function updateDataset(rawData, neighbors) {
     if (!!rawData && !!rawData['data']) {
       dataset = new Dataset(rawData, 'color');
       if (!!$frameTransformations && $frameTransformations.length > 0)
@@ -76,6 +77,10 @@
     if (!!canvas && animate) {
       canvas.animateDatasetUpdate();
     }
+  }
+
+  $: if (!!$neighborData && $neighborData.length > 0 && !!dataset) {
+    dataset.setNeighbors($neighborData);
   }
 
   onMount(() => {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -73,6 +73,7 @@
   }
 
   function updateTransformations(animate = true) {
+    if (dataset.frameCount != $frameTransformations.length) return;
     dataset.transform($frameTransformations);
     if (!!canvas && animate) {
       canvas.animateDatasetUpdate();

--- a/src/visualization/models/dataset.js
+++ b/src/visualization/models/dataset.js
@@ -6,7 +6,7 @@ import {
   ColumnarFrame,
   FramePreview,
   NeighborPreview,
-  NeighborSet,
+  Neighbors,
   PrecomputedPreview,
   ProjectionPreview,
 } from './frames';
@@ -296,7 +296,7 @@ export class Dataset {
   setNeighbors(neighborData) {
     if (neighborData.length != this.frames.length)
       console.warn('Neighbor data has different length than frames');
-    this.neighborSets = neighborData.map((n) => new NeighborSet(n));
+    this.neighborSets = neighborData.map((n) => new Neighbors(n));
     this.frames.forEach((f, i) => {
       f.linkField('highlightIndexes', this.neighborSets[i], 'neighbors');
     });

--- a/src/visualization/models/dataset.js
+++ b/src/visualization/models/dataset.js
@@ -6,6 +6,7 @@ import {
   ColumnarFrame,
   FramePreview,
   NeighborPreview,
+  NeighborSet,
   PrecomputedPreview,
   ProjectionPreview,
 } from './frames';
@@ -19,6 +20,7 @@ export const PreviewMode = {
 export class Dataset {
   frames = [];
   frameTransformations = [];
+  neighborSets = [];
   colorKey = 'color';
   length = 0; // number of points
   frameCount = 0;
@@ -288,5 +290,20 @@ export class Dataset {
     this.spritesheets = null;
     this.thumbnailData = null;
     this.frames.forEach((f) => f.removeComputedField('label'));
+  }
+
+  // neighborData should be a list of JSON objects, each representing a set of neighbors
+  setNeighbors(neighborData) {
+    if (neighborData.length != this.frames.length)
+      console.warn('Neighbor data has different length than frames');
+    this.neighborSets = neighborData.map((n) => new NeighborSet(n));
+    this.frames.forEach((f, i) => {
+      f.linkField('highlightIndexes', this.neighborSets[i], 'neighbors');
+    });
+  }
+
+  clearNeighbors() {
+    this.neighborSets = [];
+    this.frames.forEach((f) => f.removeComputedField('highlightIndexes'));
   }
 }

--- a/src/visualization/models/frames.js
+++ b/src/visualization/models/frames.js
@@ -311,13 +311,13 @@ const FRAME_SCHEMA = {
   alpha: { array: Float32Array },
   r: { array: Float32Array },
   color: { array: Array },
-  highlightIndexes: { array: 'id', field: 'highlight', nested: true },
   visible: { array: Array },
 };
 
 export class ColumnarFrame extends ColumnarData {
   _kdTree;
   title;
+  neighborSet;
 
   constructor(frame, title, additionalFields = null) {
     super(FRAME_SCHEMA, frame, additionalFields);
@@ -359,6 +359,16 @@ export class ColumnarFrame extends ColumnarData {
   neighbors(pointID, k) {
     if (!this._kdTree) this.buildKdTree();
     return this._kdTree.nearest(pointID, k);
+  }
+}
+
+const NEIGHBOR_SET_SCHEMA = {
+  neighbors: { array: 'id', nested: true },
+};
+
+export class NeighborSet extends ColumnarData {
+  constructor(data) {
+    super(NEIGHBOR_SET_SCHEMA, data);
   }
 }
 

--- a/src/visualization/models/frames.js
+++ b/src/visualization/models/frames.js
@@ -362,13 +362,13 @@ export class ColumnarFrame extends ColumnarData {
   }
 }
 
-const NEIGHBOR_SET_SCHEMA = {
+const NEIGHBORS_SCHEMA = {
   neighbors: { array: 'id', nested: true },
 };
 
-export class NeighborSet extends ColumnarData {
+export class Neighbors extends ColumnarData {
   constructor(data) {
-    super(NEIGHBOR_SET_SCHEMA, data);
+    super(NEIGHBORS_SCHEMA, data);
   }
 }
 


### PR DESCRIPTION
Adds backend support for dealing with both high-dimensional and low-dimensional neighbors at different points in the visualization. For example, when visualizing the differences between multiple 2D projections of the same data, we may want the sidebar to display high-dimensional neighbors, but for the comparison functions (color stripes, suggested selections) to operate on the low-dimensional neighbors.

In this implementation, we define two additional classes, `Neighbors` and `NeighborSet`, which contain and handle serialization of nearest neighbors. We also add two methods on `Embedding`/`EmbeddingSet`, `get_ancestor_neighbors()` and `get_recent_neighbors()`. Ancestor neighbors are the neighbors that are **farthest back** in the parent tree of an embedding, i.e. the neighbors from the highest-dimensional embedding. Recent neighbors are the **closest** neighbor set in the parent tree of an embedding, i.e. the neighbors that should be compared.

Which neighbors are used as the ancestor and recent neighbors can be controlled by deciding where to call `compute_neighbors()`, which associates a `Neighbors` object with a particular embedding. To make a certain level the target of comparison, simply clear the parent embeddings' neighbors by calling `clear_upstream_neighbors()`.